### PR TITLE
Removes dynamic imports for Firefox support

### DIFF
--- a/example.html
+++ b/example.html
@@ -2,109 +2,108 @@
 
 <script src="https://unpkg.com/vue"></script>
 <script type="module">
-import('./index.js').then(({ withHooks, useState, useEffect }) => {
-  // a custom hook that fetches from an API endpoint
-  function useAPI(endpoint) {
-    const [res, setRes] = useState({
+import { withHooks, useState, useEffect } from './index.js'
+// a custom hook that fetches from an API endpoint
+function useAPI(endpoint) {
+  const [res, setRes] = useState({
+    status: 'pending',
+    data: null,
+    error: null
+  })
+  useEffect(() => {
+    let aborted = false
+    setRes({
       status: 'pending',
       data: null,
       error: null
     })
-    useEffect(() => {
-      let aborted = false
-      setRes({
-        status: 'pending',
-        data: null,
-        error: null
-      })
-      fetch(endpoint)
-        .then(res => res.json())
-        .then(data => {
-          if (aborted) {
-            return
-          }
-          setRes({
-            status: 'success',
-            data,
-            error: null
-          })
-        }).catch(error => {
-          if (aborted) {
-            return
-          }
-          setRes({
-            status: 'error',
-            data: null,
-            error
-          })
+    fetch(endpoint)
+      .then(res => res.json())
+      .then(data => {
+        if (aborted) {
+          return
+        }
+        setRes({
+          status: 'success',
+          data,
+          error: null
         })
-      return () => {
-        aborted = true
-      }
-    }, [endpoint])
-    return res
-  }
-
-  // a custom hook that sync with window width
-  function useWindowWidth() {
-    const [width, setWidth] = useState(window.innerWidth)
-    const handleResize = () => {
-      setWidth(window.innerWidth)
-    };
-    useEffect(() => {
-      window.addEventListener("resize", handleResize)
-      return () => {
-        window.removeEventListener("resize", handleResize)
-      }
-    }, [])
-    return width
-  }
-
-  const Foo = withHooks(h => {
-    // state
-    const [count, setCount] = useState(0)
-
-    // effect
-    useEffect(() => {
-      document.title = "count is " + count
-    })
-
-    // custom hook
-    const width = useWindowWidth()
-
-    const { status, data, error } = useAPI(`https://jsonplaceholder.typicode.com/todos/${count + 1}`)
-
-    let result
-    if (status === 'pending') {
-      result = h('div', 'loading...')
-    } else if (status === 'success') {
-      result = h('pre', JSON.stringify(data))
-    } else {
-      result = h('pre', { style: { color: 'red' }}, error.toString())
+      }).catch(error => {
+        if (aborted) {
+          return
+        }
+        setRes({
+          status: 'error',
+          data: null,
+          error
+        })
+      })
+    return () => {
+      aborted = true
     }
+  }, [endpoint])
+  return res
+}
 
-    return h("div", [
-      result,
-      h("span", `count is: ${count}`),
-      h(
-        "button",
-        {
-          on: {
-            click: () => setCount(count + 1)
-          }
-        },
-        "+"
-      ),
-      h("div", `window width is: ${width}`)
-    ])
+// a custom hook that sync with window width
+function useWindowWidth() {
+  const [width, setWidth] = useState(window.innerWidth)
+  const handleResize = () => {
+    setWidth(window.innerWidth)
+  };
+  useEffect(() => {
+    window.addEventListener("resize", handleResize)
+    return () => {
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
+  return width
+}
+
+const Foo = withHooks(h => {
+  // state
+  const [count, setCount] = useState(0)
+
+  // effect
+  useEffect(() => {
+    document.title = "count is " + count
   })
 
-  // just so you know this is Vue...
-  new Vue({
-    el: "#app",
-    render(h) {
-      return h("div", [h(Foo), h(Foo)])
-    }
-  })
+  // custom hook
+  const width = useWindowWidth()
+
+  const { status, data, error } = useAPI(`https://jsonplaceholder.typicode.com/todos/${count + 1}`)
+
+  let result
+  if (status === 'pending') {
+    result = h('div', 'loading...')
+  } else if (status === 'success') {
+    result = h('pre', JSON.stringify(data))
+  } else {
+    result = h('pre', { style: { color: 'red' }}, error.toString())
+  }
+
+  return h("div", [
+    result,
+    h("span", `count is: ${count}`),
+    h(
+      "button",
+      {
+        on: {
+          click: () => setCount(count + 1)
+        }
+      },
+      "+"
+    ),
+    h("div", `window width is: ${width}`)
+  ])
+})
+
+// just so you know this is Vue...
+new Vue({
+  el: "#app",
+  render(h) {
+    return h("div", [h(Foo), h(Foo)])
+  }
 })
 </script>

--- a/example2.html
+++ b/example2.html
@@ -2,44 +2,51 @@
 
 <script src="https://unpkg.com/vue"></script>
 <script type="module">
-import('./index.js').then(({ withHooks, useData, useMounted, useUpdated, useDestroyed, useWatch, useComputed }) => {
-  // API that maps Vue's existing API
-  const Foo = withHooks(h => {
-    const data = useData({
-      count: 0
-    })
-
-    const double = useComputed(() => data.count * 2)
-
-    useWatch(() => data.count, (val, prevVal) => {
-      console.log(`count is: ${val}`)
-    })
-
-    useMounted(() => {
-      console.log('mounted!')
-    })
-    useUpdated(() => {
-      console.log('updated!')
-    })
-    useDestroyed(() => {
-      console.log('destroyed!')
-    })
-
-    return h('div', [
-      h('div', `count is ${data.count}`),
-      h('div', `double count is ${double}`),
-      h('button', { on: { click: () => {
-        // still got that direct mutation!
-        data.count++
-      }}}, 'count++')
-    ])
+import {
+  withHooks,
+  useData,
+  useMounted,
+  useUpdated,
+  useDestroyed,
+  useWatch,
+  useComputed
+} from './index.js'
+// API that maps Vue's existing API
+const Foo = withHooks(h => {
+  const data = useData({
+    count: 0
   })
 
-  new Vue({
-    el: "#app",
-    render(h) {
-      return h("div", [h(Foo), h(Foo)])
-    }
+  const double = useComputed(() => data.count * 2)
+
+  useWatch(() => data.count, (val, prevVal) => {
+    console.log(`count is: ${val}`)
   })
+
+  useMounted(() => {
+    console.log('mounted!')
+  })
+  useUpdated(() => {
+    console.log('updated!')
+  })
+  useDestroyed(() => {
+    console.log('destroyed!')
+  })
+
+  return h('div', [
+    h('div', `count is ${data.count}`),
+    h('div', `double count is ${double}`),
+    h('button', { on: { click: () => {
+      // still got that direct mutation!
+      data.count++
+    }}}, 'count++')
+  ])
+})
+
+new Vue({
+  el: "#app",
+  render(h) {
+    return h("div", [h(Foo), h(Foo)])
+  }
 })
 </script>

--- a/example3.html
+++ b/example3.html
@@ -6,31 +6,30 @@
 
 <script src="https://unpkg.com/vue"></script>
 <script type="module">
-import('./index.js').then(({ hooks, useData, useMounted, useWatch, useComputed }) => {
-  Vue.use(hooks)
+import { hooks, useData, useMounted, useWatch, useComputed } from './index.js'
+Vue.use(hooks)
 
-  new Vue({
-    el: "#app",
-    hooks() {
-      const data = useData({
-        count: 0
-      })
+new Vue({
+  el: "#app",
+  hooks() {
+    const data = useData({
+      count: 0
+    })
 
-      const double = useComputed(() => data.count * 2)
+    const double = useComputed(() => data.count * 2)
 
-      useWatch(() => data.count, (val, prevVal) => {
-        console.log(`count is: ${val}`)
-      })
+    useWatch(() => data.count, (val, prevVal) => {
+      console.log(`count is: ${val}`)
+    })
 
-      useMounted(() => {
-        console.log('mounted!')
-      })
+    useMounted(() => {
+      console.log('mounted!')
+    })
 
-      return {
-        data,
-        double
-      }
+    return {
+      data,
+      double
     }
-  })
+  }
 })
 </script>


### PR DESCRIPTION
Incredible work getting this out so quickly. Fair play :+1:

There's an issue getting the examples working in Firefox as it doesn't support dynamic import(). This updates the scripts to use regular imports.