### PR TITLE
Fixing typo 'lenght' to 'length'

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ export function useEffect(rawEffect, deps) {
 
     currentInstance.$on('hook:mounted', effect)
     currentInstance.$on('hook:destroyed', cleanup)
-    if (!deps || deps.lenght > 0) {
+    if (!deps || deps.length > 0) {
       currentInstance.$on('hook:updated', effect)
     }
   } else {


### PR DESCRIPTION
Just noticed a small typo when checking for property `length`